### PR TITLE
Add --ssl flag for HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ LightRAG MCP server supports two MCP transport modes:
 LightRAG API connection:
 
 - `--host`: LightRAG API host (default: localhost)
-- `--port`: LightRAG API port (default: 9621)
+- `--port`: LightRAG API port (default: 9621, or 443 when `--ssl` is set)
 - `--api-key`: LightRAG API key (optional)
+- `--ssl`: Use HTTPS instead of HTTP (default: False)
 
 MCP transport:
 
@@ -91,6 +92,24 @@ To set up LightRAG MCP as an MCP server, add the following configuration to your
         "9621",
         "--api-key",
         "your_api_key"
+      ]
+    }
+  }
+}
+```
+
+#### Using HTTPS (SSL):
+
+```json
+{
+  "mcpServers": {
+    "lightrag-mcp": {
+      "command": "uvx",
+      "args": [
+        "lightrag_mcp",
+        "--host",
+        "lightrag.example.com",
+        "--ssl"
       ]
     }
   }

--- a/src/lightrag_mcp/config.py
+++ b/src/lightrag_mcp/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 9621
+DEFAULT_SSL_PORT = 443
 DEFAULT_API_KEY = ""
 
 DEFAULT_MCP_TRANSPORT = "stdio"
@@ -22,10 +23,15 @@ class LightRAGSettings:
     host: str
     port: int
     api_key: str
+    ssl: bool = False
 
     @property
     def base_url(self) -> str:
-        return f"http://{self.host}:{self.port}"
+        scheme = "https" if self.ssl else "http"
+        # Omit the port when it is the scheme's default (https -> 443, http -> 80).
+        default_port = 443 if self.ssl else 80
+        port_suffix = "" if self.port == default_port else f":{self.port}"
+        return f"{scheme}://{self.host}{port_suffix}"
 
 
 @dataclass(frozen=True)
@@ -61,10 +67,18 @@ def parse_args():
     parser.add_argument(
         "--port",
         type=int,
-        default=DEFAULT_PORT,
-        help=f"LightRAG API port (default: {DEFAULT_PORT})",
+        default=None,
+        help=(
+            "LightRAG API port "
+            f"(default: {DEFAULT_PORT}, or {DEFAULT_SSL_PORT} when --ssl is set)"
+        ),
     )
     parser.add_argument("--api-key", default=DEFAULT_API_KEY, help="LightRAG API key (optional)")
+    parser.add_argument(
+        "--ssl",
+        action="store_true",
+        help="Use HTTPS instead of HTTP (default: False)",
+    )
     parser.add_argument(
         "--mcp-transport",
         choices=["stdio", "streamable-http"],
@@ -105,10 +119,18 @@ def parse_args():
 
 args = parse_args()
 
+# Resolve the API port: an explicit --port always wins, otherwise pick the
+# default for the scheme (443 for HTTPS, 9621 for plain HTTP).
+if args.port is not None:
+    _lightrag_port = args.port
+else:
+    _lightrag_port = DEFAULT_SSL_PORT if args.ssl else DEFAULT_PORT
+
 LIGHTRAG = LightRAGSettings(
     host=args.host,
-    port=args.port,
+    port=_lightrag_port,
     api_key=args.api_key,
+    ssl=args.ssl,
 )
 MCP = MCPSettings(
     transport=args.mcp_transport,
@@ -122,6 +144,7 @@ MCP = MCPSettings(
 LIGHTRAG_API_HOST = LIGHTRAG.host
 LIGHTRAG_API_PORT = LIGHTRAG.port
 LIGHTRAG_API_KEY = LIGHTRAG.api_key
+LIGHTRAG_API_SSL = LIGHTRAG.ssl
 LIGHTRAG_API_BASE_URL = LIGHTRAG.base_url
 
 MCP_TRANSPORT = MCP.transport


### PR DESCRIPTION
## Summary

This PR adds a new `--ssl` command line flag that enables HTTPS connections to the LightRAG API server. This is useful when the API is served behind a reverse proxy with TLS termination (e.g., Caddy, nginx, Traefik).

## Changes

- Added `--ssl` argument to argparse in `config.py`
- Updated URL construction logic to use `https://` when `--ssl` is set
- When `--ssl` is used with default port 443, the port suffix is omitted from the URL
- Updated README with documentation and example configuration

## Usage

```bash
uvx lightrag-mcp --host lightrag.example.com --ssl
```

Or in MCP config:
```json
{
  "mcpServers": {
    "lightrag-mcp": {
      "command": "uvx",
      "args": ["lightrag_mcp", "--host", "lightrag.example.com", "--ssl"]
    }
  }
}
```

## Test plan

- [x] Verify `--ssl` flag is accepted by argparse
- [x] Verify URL is constructed as `https://host` when `--ssl` is used
- [x] Verify port 443 is omitted from URL when using `--ssl` with default port
- [x] Verify custom ports still work with `--ssl` (e.g., `--ssl --port 8443`)