### PR TITLE
rewired for HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,26 @@ uv pip install -e .
 
 ## Usage
 
-**Important**: LightRAG MCP server should only be run as an MCP server through an MCP client configuration file (mcp-config.json).
+LightRAG MCP server supports two MCP transport modes:
+- **stdio (default)**: run through an MCP client configuration file (`mcp-config.json`)
+- **streamable-http**: run as a standalone HTTP server for remote MCP clients
 
 ### Command Line Options
 
-The following arguments are available when configuring the server in mcp-config.json:
+LightRAG API connection:
 
 - `--host`: LightRAG API host (default: localhost)
 - `--port`: LightRAG API port (default: 9621)
 - `--api-key`: LightRAG API key (optional)
+
+MCP transport:
+
+- `--mcp-transport`: MCP transport (`stdio` or `streamable-http`, default: stdio)
+- `--mcp-host`: MCP HTTP host (default: 127.0.0.1)
+- `--mcp-port`: MCP HTTP port (default: 8000)
+- `--mcp-streamable-http-path`: Streamable HTTP endpoint path (default: /mcp)
+- `--mcp-stateless-http`: Enable stateless Streamable HTTP mode (new session per request)
+- `--mcp-json-response`: Return JSON responses instead of SSE for Streamable HTTP
 
 ### Integration with LightRAG API
 
@@ -61,7 +72,7 @@ uv pip install -r LightRAG/lightrag/api/requirements.txt
 uv run LightRAG/lightrag/api/lightrag_server.py --host localhost --port 9621 --working-dir ./rag_storage --input-dir ./input --llm-binding openai --embedding-binding openai --log-level DEBUG
 ```
 
-### Setting up as MCP server
+### Setting up as MCP server (stdio)
 
 To set up LightRAG MCP as an MCP server, add the following configuration to your MCP client configuration file (e.g., `mcp-config.json`):
 
@@ -111,6 +122,23 @@ To set up LightRAG MCP as an MCP server, add the following configuration to your
 ```
 
 Replace `/path/to/lightrag_mcp` with the actual path to your lightrag-mcp directory.
+
+### Running over Streamable HTTP (standalone server)
+
+Use this when you need remote access or want to host the MCP server behind HTTP infrastructure:
+
+```bash
+uv run src/lightrag_mcp/main.py \
+  --mcp-transport streamable-http \
+  --mcp-host 0.0.0.0 \
+  --mcp-port 8000 \
+  --mcp-streamable-http-path /mcp \
+  --host localhost \
+  --port 9621 \
+  --api-key your_api_key
+```
+
+MCP clients should connect to: `http://localhost:8000/mcp`
 
 ## Available MCP Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "shemhamforash", email = "killsterak16@gmail.com"},
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.6.0",
     "httpx>=0.28.1",
     "pydantic>=2.11",
     "python-dotenv>=1.0.1",

--- a/src/lightrag_mcp/config.py
+++ b/src/lightrag_mcp/config.py
@@ -3,17 +3,60 @@ Configuration module for LightRAG MCP server.
 """
 
 import argparse
+from dataclasses import dataclass
 
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 9621
 DEFAULT_API_KEY = ""
+
+DEFAULT_MCP_TRANSPORT = "stdio"
+DEFAULT_MCP_HOST = "127.0.0.1"
+DEFAULT_MCP_PORT = 8000
+DEFAULT_MCP_STREAMABLE_HTTP_PATH = "/mcp"
+
+
+@dataclass(frozen=True)
+class LightRAGSettings:
+    """Settings for connecting to the LightRAG API server."""
+
+    host: str
+    port: int
+    api_key: str
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+
+@dataclass(frozen=True)
+class MCPSettings:
+    """Settings for MCP transport and HTTP server."""
+
+    transport: str
+    host: str
+    port: int
+    streamable_http_path: str
+    stateless_http: bool
+    json_response: bool
+
+    @property
+    def streamable_http_url(self) -> str:
+        return f"http://{self.host}:{self.port}{self.streamable_http_path}"
+
+
+def _normalize_path(path: str) -> str:
+    if not path.startswith("/"):
+        return f"/{path}"
+    return path
 
 
 def parse_args():
     """Parse command line arguments for LightRAG MCP server."""
     parser = argparse.ArgumentParser(description="LightRAG MCP Server")
     parser.add_argument(
-        "--host", default=DEFAULT_HOST, help=f"LightRAG API host (default: {DEFAULT_HOST})"
+        "--host",
+        default=DEFAULT_HOST,
+        help=f"LightRAG API host (default: {DEFAULT_HOST})",
     )
     parser.add_argument(
         "--port",
@@ -22,12 +65,69 @@ def parse_args():
         help=f"LightRAG API port (default: {DEFAULT_PORT})",
     )
     parser.add_argument("--api-key", default=DEFAULT_API_KEY, help="LightRAG API key (optional)")
+    parser.add_argument(
+        "--mcp-transport",
+        choices=["stdio", "streamable-http"],
+        default=DEFAULT_MCP_TRANSPORT,
+        help=f"MCP transport (default: {DEFAULT_MCP_TRANSPORT})",
+    )
+    parser.add_argument(
+        "--mcp-host",
+        default=DEFAULT_MCP_HOST,
+        help=f"MCP HTTP host (default: {DEFAULT_MCP_HOST})",
+    )
+    parser.add_argument(
+        "--mcp-port",
+        type=int,
+        default=DEFAULT_MCP_PORT,
+        help=f"MCP HTTP port (default: {DEFAULT_MCP_PORT})",
+    )
+    parser.add_argument(
+        "--mcp-streamable-http-path",
+        default=DEFAULT_MCP_STREAMABLE_HTTP_PATH,
+        help=(
+            "Streamable HTTP path for MCP endpoint "
+            f"(default: {DEFAULT_MCP_STREAMABLE_HTTP_PATH})"
+        ),
+    )
+    parser.add_argument(
+        "--mcp-stateless-http",
+        action="store_true",
+        help="Enable stateless Streamable HTTP mode (new session per request)",
+    )
+    parser.add_argument(
+        "--mcp-json-response",
+        action="store_true",
+        help="Return JSON responses instead of SSE for Streamable HTTP",
+    )
     return parser.parse_args()
 
 
 args = parse_args()
 
-LIGHTRAG_API_HOST = args.host
-LIGHTRAG_API_PORT = args.port
-LIGHTRAG_API_KEY = args.api_key
-LIGHTRAG_API_BASE_URL = f"http://{LIGHTRAG_API_HOST}:{LIGHTRAG_API_PORT}"
+LIGHTRAG = LightRAGSettings(
+    host=args.host,
+    port=args.port,
+    api_key=args.api_key,
+)
+MCP = MCPSettings(
+    transport=args.mcp_transport,
+    host=args.mcp_host,
+    port=args.mcp_port,
+    streamable_http_path=_normalize_path(args.mcp_streamable_http_path),
+    stateless_http=args.mcp_stateless_http,
+    json_response=args.mcp_json_response,
+)
+
+LIGHTRAG_API_HOST = LIGHTRAG.host
+LIGHTRAG_API_PORT = LIGHTRAG.port
+LIGHTRAG_API_KEY = LIGHTRAG.api_key
+LIGHTRAG_API_BASE_URL = LIGHTRAG.base_url
+
+MCP_TRANSPORT = MCP.transport
+MCP_HOST = MCP.host
+MCP_PORT = MCP.port
+MCP_STREAMABLE_HTTP_PATH = MCP.streamable_http_path
+MCP_STATELESS_HTTP = MCP.stateless_http
+MCP_JSON_RESPONSE = MCP.json_response
+MCP_STREAMABLE_HTTP_URL = MCP.streamable_http_url

--- a/src/lightrag_mcp/main.py
+++ b/src/lightrag_mcp/main.py
@@ -26,14 +26,23 @@ def main():
 
         logger.info("Starting LightRAG MCP server")
         logger.info(
-            f"LightRAG API server is expected to be already running and available at: {config.LIGHTRAG_API_BASE_URL}"
+            "LightRAG API server is expected to be already running and available at: "
+            f"{config.LIGHTRAG.base_url}"
         )
-        if config.LIGHTRAG_API_KEY:
+        logger.info(f"MCP transport: {config.MCP_TRANSPORT}")
+        if config.MCP_TRANSPORT == "streamable-http":
+            logger.info(f"Streamable HTTP endpoint: {config.MCP_STREAMABLE_HTTP_URL}")
+            if config.MCP_STATELESS_HTTP:
+                logger.info("Streamable HTTP mode: stateless")
+            if config.MCP_JSON_RESPONSE:
+                logger.info("Streamable HTTP mode: json_response")
+
+        if config.LIGHTRAG.api_key:
             logger.info("API key is configured")
         else:
             logger.warning("No API key provided")
 
-        mcp.run(transport="stdio")
+        mcp.run(transport=config.MCP_TRANSPORT)
 
     except KeyboardInterrupt:
         logger.info("Server stopped by user")

--- a/src/lightrag_mcp/server.py
+++ b/src/lightrag_mcp/server.py
@@ -17,8 +17,6 @@ from lightrag_mcp.lightrag_client import LightRAGClient
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP("LightRAG MCP Server")
-
 
 def format_response(result: Any, is_error: bool = False) -> Dict[str, Any]:
     """
@@ -66,8 +64,8 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     Initializes LightRAG API client at startup and closes it at shutdown.
     """
     lightrag_client = LightRAGClient(
-        base_url=config.LIGHTRAG_API_BASE_URL,
-        api_key=config.LIGHTRAG_API_KEY,
+        base_url=config.LIGHTRAG.base_url,
+        api_key=config.LIGHTRAG.api_key,
     )
 
     try:
@@ -77,7 +75,15 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
         logger.info("LightRAG MCP Server stopped")
 
 
-mcp = FastMCP("LightRAG MCP Server", lifespan=app_lifespan)
+mcp = FastMCP(
+    "LightRAG MCP Server",
+    lifespan=app_lifespan,
+    host=config.MCP_HOST,
+    port=config.MCP_PORT,
+    streamable_http_path=config.MCP_STREAMABLE_HTTP_PATH,
+    stateless_http=config.MCP_STATELESS_HTTP,
+    json_response=config.MCP_JSON_RESPONSE,
+)
 
 
 async def execute_lightrag_operation(


### PR DESCRIPTION
Added Streamable HTTP transport configuration with a clean separation between LightRAG API settings and MCP transport settings. Wired those settings into FastMCP initialization and mcp.run().

`stdio` remains the default while streamable HTTP is a supported runtime option. 

Documentation now explicitly covers both stdio and Streamable HTTP usage, and the mcp minimum version is bumped to ensure the streamable transport is available.

Changes:
- New MCP transport settings + dataclass abstractions in `src/lightrag_mcp/config.py`.
- FastMCP init and runtime transport selection updated in `src/lightrag_mcp/server.py` and `src/lightrag_mcp/main.py`.
- README now documents Streamable HTTP usage and new CLI flags in `README.md`.
- Dependency updated to `mcp>=1.6.0` in `pyproject.toml`.